### PR TITLE
Add S3 key type support

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,4 +1,4 @@
-Release 0.2.1 - 2018-08-08
+Release 0.2.1 - 2018-08-15
 
 * Add `key_type` config, supports "inline" and "s3".
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+Release 0.3.0 - 2018-08-08
+
+* Add `key_type` config, supports "inline" and "s3".
+
 Release 0.2.0 - 2018-06-13
 
 * Add `output_encoding` config, supports "base64" and "hex".

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,4 +1,4 @@
-Release 0.3.0 - 2018-08-08
+Release 0.2.1 - 2018-08-08
 
 * Add `key_type` config, supports "inline" and "s3".
 

--- a/README.md
+++ b/README.md
@@ -22,10 +22,17 @@ You can apply encryption to password column and get following outputs:
 
 - **algorithm**: encryption algorithm (see below) (enum, required)
 - **column_names**: names of string columns to encrypt (array of string, required)
-- **key_hex**: encryption key (string, required)
-- **iv_hex**: encryption initialization vector (string, required if mode of the algorithm is CBC)
+- **key_type**: encryption key (enum, optional, default: inline), can be either "inline" or "s3"
+- **key_hex**: encryption key (string, required if key_type is inline)
+- **iv_hex**: encryption initialization vector (string, required if mode of the algorithm is CBC and key_type is inline)
 - **output_encoding**: the encoding of encrypted value, can be either "base64" or "hex" (base16)
-
+- **aws_params**: AWS/S3 parameters (hash, required if key_type is s3)
+    - **region**: a valid AWS region
+    - **access_key**: a valid AWS access key
+    - **secret_key**: a valid AWS secret key
+    - **bucket**: a valid S3 bucket
+    - **path**: a valid S3 key (S3 file path)
+    
 ## Algorithms
 
 Available algorithms are:
@@ -115,6 +122,8 @@ You can use Hive's `aes_decrypt(input binary, key binary)` function (available s
 
 ## Example
 
+* Inline key type
+
 ```yaml
 filters:
   - type: encrypt
@@ -123,6 +132,23 @@ filters:
     key_hex: 098F6BCD4621D373CADE4E832627B4F60A9172716AE6428409885B8B829CCB05
     iv_hex: C9DD4BB33B827EB1FBA1B16A0074D460
     output_encoding: hex
+```
+
+* S3 key type
+
+```yaml
+filters:
+  - type: encrypt
+    algorithm: AES-256-CBC
+    column_names: [password, ip]
+    output_encoding: hex
+    key_type: s3
+    aws_params:
+      region: us-east-2
+      access_key: XXXXXXXXXXXXXXXXXXXX
+      secret_key: xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+      bucket: com.sample.keys
+      path: key.aes
 ```
 
 ## Build

--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ configurations {
     provided
 }
 
-version = "0.2.0"
+version = "0.2.1"
 
 sourceCompatibility = 1.7
 targetCompatibility = 1.7

--- a/build.gradle
+++ b/build.gradle
@@ -21,9 +21,11 @@ targetCompatibility = 1.7
 dependencies {
     compile  "org.embulk:embulk-core:0.8.6"
     provided "org.embulk:embulk-core:0.8.6"
-    // compile "YOUR_JAR_DEPENDENCY_GROUP:YOUR_JAR_DEPENDENCY_MODULE:YOUR_JAR_DEPENDENCY_VERSION"
+    compile "com.amazonaws:aws-java-sdk-s3:1.11.253"
+
     testCompile "junit:junit:4.+"
     testCompile "org.embulk:embulk-core:0.8.18:tests"
+    testCompile "org.mockito:mockito-core:2.+"
 }
 
 task classpath(type: Copy, dependsOn: ["jar"]) {

--- a/src/main/java/org/embulk/filter/encrypt/EncryptFilterPlugin.java
+++ b/src/main/java/org/embulk/filter/encrypt/EncryptFilterPlugin.java
@@ -259,6 +259,9 @@ public class EncryptFilterPlugin
 
         try {
             fullObject = client.getObject(new GetObjectRequest(bucket, path));
+            if (fullObject == null) {
+                throw new ConfigException("S3 key file is not enabled to be retrieved");
+            }
             return (Map<String, String>) yaml.load(fullObject.getObjectContent());
         }
         catch (AmazonServiceException e) {
@@ -273,6 +276,9 @@ public class EncryptFilterPlugin
                 }
             }
             throw e;
+        }
+        catch (ClassCastException e) {
+            throw new ConfigException("S3 key file content is unexpected format");
         }
         finally {
             // To ensure that the network connection doesn't remain open, close any open input streams.
@@ -336,9 +342,7 @@ public class EncryptFilterPlugin
                 AWSParams params = task.getAWSParams().get();
                 AmazonS3 s3Client = newS3Client(params);
                 Map<String, String> keys = retrieveKey(params.getBucket(), params.getPath(), s3Client);
-                if (keys == null) {
-                    throw new ConfigException("Key file is in incorrect format or not enable to be retrieved");
-                }
+
                 String key = keys.get("key_hex");
                 if (isNullOrEmpty(key)) {
                     throw new ConfigException("Field 'key_hex' is required but not set");

--- a/src/main/java/org/embulk/filter/encrypt/EncryptFilterPlugin.java
+++ b/src/main/java/org/embulk/filter/encrypt/EncryptFilterPlugin.java
@@ -1,7 +1,16 @@
 package org.embulk.filter.encrypt;
 
+import com.amazonaws.AmazonServiceException;
+import com.amazonaws.auth.AWSCredentials;
+import com.amazonaws.auth.AWSCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import com.amazonaws.services.s3.model.GetObjectRequest;
+import com.amazonaws.services.s3.model.S3Object;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Optional;
 import com.google.common.io.BaseEncoding;
 import org.embulk.config.Config;
@@ -10,6 +19,7 @@ import org.embulk.config.ConfigException;
 import org.embulk.config.ConfigSource;
 import org.embulk.config.Task;
 import org.embulk.config.TaskSource;
+import org.embulk.config.YamlTagResolver;
 import org.embulk.spi.Column;
 import org.embulk.spi.ColumnVisitor;
 import org.embulk.spi.DataException;
@@ -21,6 +31,10 @@ import org.embulk.spi.PageOutput;
 import org.embulk.spi.PageReader;
 import org.embulk.spi.Schema;
 import org.slf4j.Logger;
+import org.yaml.snakeyaml.DumperOptions;
+import org.yaml.snakeyaml.Yaml;
+import org.yaml.snakeyaml.constructor.SafeConstructor;
+import org.yaml.snakeyaml.representer.Representer;
 
 import javax.crypto.BadPaddingException;
 import javax.crypto.Cipher;
@@ -29,12 +43,15 @@ import javax.crypto.NoSuchPaddingException;
 import javax.crypto.spec.IvParameterSpec;
 import javax.crypto.spec.SecretKeySpec;
 
+import java.io.IOException;
 import java.security.InvalidAlgorithmParameterException;
 import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
 import java.util.EnumSet;
 import java.util.List;
+import java.util.Map;
 
+import static com.google.common.base.Strings.isNullOrEmpty;
 import static java.lang.String.format;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.apache.commons.lang3.StringUtils.join;
@@ -42,7 +59,7 @@ import static org.apache.commons.lang3.StringUtils.join;
 public class EncryptFilterPlugin
         implements FilterPlugin
 {
-    public static enum Algorithm
+    public enum Algorithm
     {
         AES_256_CBC("AES/CBC/PKCS5Padding", "AES", 256, true, "AES", "AES-256", "AES-256-CBC"),
         AES_192_CBC("AES/CBC/PKCS5Padding", "AES", 192, true, "AES-192", "AES-192-CBC"),
@@ -57,7 +74,7 @@ public class EncryptFilterPlugin
         private final boolean useIv;
         private String[] displayNames;
 
-        private Algorithm(String javaName, String javaKeySpecName, int keyLength, boolean useIv, String... displayNames)
+        Algorithm(String javaName, String javaKeySpecName, int keyLength, boolean useIv, String... displayNames)
         {
             this.javaName = javaName;
             this.javaKeySpecName = javaKeySpecName;
@@ -149,6 +166,25 @@ public class EncryptFilterPlugin
         }
     }
 
+    public enum KeyType
+    {
+        INLINE,
+        S3;
+
+        @JsonCreator
+        public static KeyType of(String value)
+        {
+            return KeyType.valueOf(value.toUpperCase());
+        }
+
+        @Override
+        @JsonValue
+        public String toString()
+        {
+            return super.toString().toLowerCase();
+        }
+    }
+
     public interface PluginTask
             extends Task
     {
@@ -159,15 +195,46 @@ public class EncryptFilterPlugin
         @ConfigDefault("\"base64\"")
         public Encoder getOutputEncoding();
 
+        @Config("key_type")
+        @ConfigDefault("\"inline\"")
+        KeyType getKeyType();
+
         @Config("key_hex")
-        public String getKeyHex();
+        @ConfigDefault("null")
+        public Optional<String> getKeyHex();
+
+        public void setKeyHex(Optional<String> key);
 
         @Config("iv_hex")
         @ConfigDefault("null")
         public Optional<String> getIvHex();
 
+        public void setIvHex(Optional<String> iv);
+
+        @Config("aws_params")
+        @ConfigDefault("null")
+        public Optional<AWSParams> getAWSParams();
+
         @Config("column_names")
         public List<String> getColumnNames();
+    }
+
+    public interface AWSParams extends Task
+    {
+        @Config("region")
+        public String getRegion();
+
+        @Config("access_key")
+        public String getAccessKey();
+
+        @Config("secret_key")
+        public String getSecretKey();
+
+        @Config("bucket")
+        public String getBucket();
+
+        @Config("path")
+        public String getPath();
     }
 
     private static final Logger log = Exec.getLogger(EncryptFilterPlugin.class);
@@ -178,27 +245,126 @@ public class EncryptFilterPlugin
     {
         PluginTask task = config.loadConfig(PluginTask.class);
 
-        if (task.getAlgorithm().useIv() && !task.getIvHex().isPresent()) {
-            throw new ConfigException("Algorithm '" + task.getAlgorithm() + "' requires initialization vector. Please generate one and set it to iv_hex option.");
+        validateAndResolveKey(task, inputSchema);
+
+        control.run(task.dump(), inputSchema);
+    }
+
+    @VisibleForTesting
+    public Map<String, String> retrieveKey(final String bucket, final String path, final AmazonS3 client)
+    {
+        S3Object fullObject = null;
+
+        try {
+            fullObject = client.getObject(new GetObjectRequest(bucket, path));
+            Yaml yaml = new Yaml(new SafeConstructor(), new Representer(), new DumperOptions(), new YamlTagResolver());
+            return (Map<String, String>) yaml.load(fullObject.getObjectContent());
         }
-        else if (!task.getAlgorithm().useIv() && task.getIvHex().isPresent()) {
-            log.warn("Algorithm '" + task.getAlgorithm() + "' doesn't use initialization vector. Please remove iv_hex option.");
+        catch (AmazonServiceException e) {
+            // The call was transmitted successfully, but Amazon S3 couldn't process
+            // it, so it returned an error response.
+            if (e.getErrorType().equals(AmazonServiceException.ErrorType.Client)) {
+                // HTTP 40x errors. auth error, bucket doesn't exist, etc. See AWS document for the full list:
+                // http://docs.aws.amazon.com/AmazonS3/latest/API/ErrorResponses.html
+                if (e.getStatusCode() != 400
+                        || "ExpiredToken".equalsIgnoreCase(e.getErrorCode())) {
+                    throw new ConfigException(e);
+                }
+            }
+            throw e;
+        }
+        finally {
+            // To ensure that the network connection doesn't remain open, close any open input streams.
+            if (fullObject != null) {
+                try {
+                    fullObject.close();
+                }
+                catch (IOException e) {
+                    log.warn("Failure to close S3 Object input stream", e);
+                }
+            }
+        }
+    }
+
+    @VisibleForTesting
+    public AmazonS3 newS3Client(final AWSParams awsParams)
+    {
+        AWSCredentialsProvider awsCredentialsProvider = new AWSCredentialsProvider()
+        {
+            @Override
+            public AWSCredentials getCredentials()
+            {
+                return new BasicAWSCredentials(awsParams.getAccessKey(), awsParams.getSecretKey());
+            }
+
+            @Override
+            public void refresh()
+            {
+            }
+        };
+
+        return AmazonS3ClientBuilder.standard()
+                .withRegion(awsParams.getRegion())
+                .withCredentials(awsCredentialsProvider)
+                .build();
+    }
+
+    private void validateAndResolveKey(PluginTask task, Schema schema) throws ConfigException
+    {
+        switch (task.getKeyType()) {
+            case INLINE:
+                if (!task.getKeyHex().isPresent()) {
+                    throw new ConfigException("Field 'key_hex' is required but not set");
+                }
+                if (task.getAlgorithm().useIv() && !task.getIvHex().isPresent()) {
+                    throw new ConfigException("Algorithm '" + task.getAlgorithm() + "' requires initialization vector. Please generate one and set it to iv_hex option.");
+                }
+                else if (!task.getAlgorithm().useIv() && task.getIvHex().isPresent()) {
+                    log.warn("Algorithm '" + task.getAlgorithm() + "' doesn't use initialization vector. iv_hex is ignored");
+                }
+                break;
+            case S3:
+                if (!task.getAWSParams().isPresent()) {
+                    throw new ConfigException("AWS Params are required for S3 Key type");
+                }
+                AWSParams params = task.getAWSParams().get();
+                AmazonS3 s3Client = newS3Client(params);
+                Map<String, String> keys = retrieveKey(params.getBucket(), params.getPath(), s3Client);
+                if (keys == null) {
+                    throw new ConfigException("Key file is in incorrect format or not enable to be retrieved");
+                }
+                String key = keys.get("key_hex");
+                if (isNullOrEmpty(key)) {
+                    throw new ConfigException("Field 'key_hex' is required but not set");
+                }
+                String iv = keys.get("iv_hex");
+                if (task.getAlgorithm().useIv() && isNullOrEmpty(iv)) {
+                    throw new ConfigException("Algorithm '" + task.getAlgorithm() + "' requires initialization vector. Please generate one and set it to iv_hex option.");
+                }
+                else if (!task.getAlgorithm().useIv() && !isNullOrEmpty(iv)) {
+                    log.warn("Algorithm '" + task.getAlgorithm() + "' doesn't use initialization vector. iv_hex is ignored");
+                }
+                task.setKeyHex(Optional.of(key));
+                if (!isNullOrEmpty(iv)) {
+                    task.setIvHex(Optional.of(iv));
+                }
+                break;
+            default:
+                throw new ConfigException(String.format("Key type [%s] is not supported", task.getKeyType().toString()));
         }
 
-        // validate configuration
+        // Validate Cipher
         try {
-            getCipher(Cipher.ENCRYPT_MODE, task);
+            getCipher(Cipher.DECRYPT_MODE, task);
         }
-        catch (Exception ex) {
-            throw new ConfigException(ex);
+        catch (Exception e) {
+            throw new ConfigException(e);
         }
 
         // validate column_names
         for (String name : task.getColumnNames()) {
-            inputSchema.lookupColumn(name);
+            schema.lookupColumn(name);
         }
-
-        control.run(task.dump(), inputSchema);
     }
 
     private Cipher getCipher(int mode, PluginTask task)
@@ -206,7 +372,7 @@ public class EncryptFilterPlugin
     {
         Algorithm algo = task.getAlgorithm();
 
-        byte[] keyData = BaseEncoding.base16().decode(task.getKeyHex());
+        byte[] keyData = BaseEncoding.base16().decode(task.getKeyHex().get());
         SecretKeySpec key = new SecretKeySpec(keyData, algo.getJavaKeySpecName());
 
         if (algo.useIv()) {

--- a/src/main/java/org/embulk/filter/encrypt/EncryptFilterPlugin.java
+++ b/src/main/java/org/embulk/filter/encrypt/EncryptFilterPlugin.java
@@ -355,7 +355,7 @@ public class EncryptFilterPlugin
 
         // Validate Cipher
         try {
-            getCipher(Cipher.DECRYPT_MODE, task);
+            getCipher(Cipher.ENCRYPT_MODE, task);
         }
         catch (Exception e) {
             throw new ConfigException(e);

--- a/src/test/java/org/embulk/filter/encrypt/TestEncryptFilterPlugin.java
+++ b/src/test/java/org/embulk/filter/encrypt/TestEncryptFilterPlugin.java
@@ -658,7 +658,7 @@ public class TestEncryptFilterPlugin
     }
 
     @Test
-    public void s3_client_should_relect_region_config()
+    public void s3_client_should_reflect_region_config()
     {
         ConfigSource configSource = s3Config()
                 .set("column_names", ImmutableList.of("attempt_to_encrypt"));
@@ -666,6 +666,19 @@ public class TestEncryptFilterPlugin
         AmazonS3 s3Client = plugin.newS3Client(configSource.loadConfig(EncryptFilterPlugin.PluginTask.class).getAWSParams().get());
 
         assertEquals(s3Client.getRegion(), Region.US_East_2);
+    }
+
+    @Test
+    public void s3_client_invalid_region_should_yell_a_meaningful_ConfigException()
+    {
+        ConfigSource configSource = s3Config()
+                .set("column_names", ImmutableList.of("attempt_to_encrypt"));
+        configSource.getNested("aws_params")
+                .set("region", "invalid_region");
+
+        expectedException.expect(ConfigException.class);
+        expectedException.expectMessage("Unable to find a region via the region provider chain");
+        plugin.newS3Client(configSource.loadConfig(EncryptFilterPlugin.PluginTask.class).getAWSParams().get());
     }
 
     /** Apply the filter to a single record */

--- a/src/test/java/org/embulk/filter/encrypt/TestEncryptFilterPlugin.java
+++ b/src/test/java/org/embulk/filter/encrypt/TestEncryptFilterPlugin.java
@@ -669,7 +669,7 @@ public class TestEncryptFilterPlugin
     }
 
     /** Apply the filter to a single record */
-    private PageReader applyFilter(final ConfigSource config, final Schema schema, final Object... rawRecord)
+    private PageReader applyFilter(ConfigSource config, final Schema schema, final Object... rawRecord)
     {
         if (rawRecord.length > schema.getColumnCount()) {
             throw new UnsupportedOperationException("applyFilter() only supports a single record, " +

--- a/src/test/java/org/embulk/filter/encrypt/TestEncryptFilterPlugin.java
+++ b/src/test/java/org/embulk/filter/encrypt/TestEncryptFilterPlugin.java
@@ -584,24 +584,6 @@ public class TestEncryptFilterPlugin
     }
 
     @Test
-    public void null_of_key_retrieval_for_s3_should_yell_a_meaningful_ConfigException()
-    {
-        ConfigSource config = s3Config()
-                .set("column_names", ImmutableList.of("attempt_to_encrypt"));
-        Schema schema = Schema.builder()
-                .add("attempt_to_encrypt", Types.STRING)
-                .build();
-
-        plugin = spy(plugin);
-
-        doReturn(null).when(plugin).retrieveKey(any(String.class), any(String.class), any(AmazonS3.class));
-
-        expectedException.expect(ConfigException.class);
-        expectedException.expectMessage("Key file is in incorrect format or not enable to be retrieved");
-        applyFilter(config, schema, ImmutableList.of("Try to encrypt me buddy!"));
-    }
-
-    @Test
     public void absence_of_encryption_key_for_s3_should_yell_a_meaningful_ConfigException()
     {
         ConfigSource config = s3Config()


### PR DESCRIPTION
This PR add ability to retrieve key and IV from S3 bucket : 

> filters: 
      - type: encrypt,
      algorithm: AES-256-CBC,
      column_names: [password],
      key_type: s3,
      aws_params:
          region: us-east-2,
          access_key: XXXXXXXXXX,
          secret_key: xxxxxxxxxxxxxxxxxxxxxxx,
          bucket: com.example_keys,
          path: key.aes