### PR TITLE
Nominate developers

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -137,6 +137,22 @@ publishing {
                 }
 
                 developers {
+                    developer {
+                        name = "Sadayuki Furuhashi"
+                        email = "frsyuki@gmail.com"
+                    }
+                    developer {
+                        name = "Huy Le"
+                        email = "huy.lenq@gmail.com"
+                    }
+                    developer {
+                        name = "Vinh Vo"
+                        email = "vinhvd@gmail.com"
+                    }
+                    developer {
+                        name = "Dai MIKURUBE"
+                        email = "dmikurube@treasure-data.com"
+                    }
                 }
 
                 scm {


### PR DESCRIPTION
We're going to release JARs of `embulk-filter-encrypt` to Maven Central from 0.3.0 (#6).

Maven Central needs the `<developers>` section available in `pom.xml`. Having the contributing developers there explicitly.